### PR TITLE
Add new libs, clients and deployments links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,24 @@
 
 - [Libraries](#libraries)
 - [Deployment](#deployment)
+- [Clients](#clients)
 - [APIs](#apis)
 
 ## Libraries
 
 - [go-gandi](https://github.com/go-gandi/go-gandi) - A Go library for Gandi V5 APIs.
+- [Lego](https://github.com/go-acme/lego) - A ACME client and library that supports Gandi V5 API and built in Go.
+- [LibDNS](https://github.com/libdns/libdns) - A Universal DNS provider APIs for Go with a [Gandi V5 provider](https://github.com/libdns/gandi) available.
 
 ## Deployment
 
 - [Gandi Terraform Provider](https://github.com/go-gandi/terraform-provider-gandi) - A Terraform provider to manages Gandi resources (domains, mailboxes, etc.).
+- [Ansible Gandi LiveDNS](https://docs.ansible.com/ansible/latest/collections/community/general/gandi_livedns_module.html) - A Ansible module for managing Gandi LiveDNS records.
+
+## Clients
+
+- [Lego](https://go-acme.github.io/lego/usage/cli/) - A ACME client and library that supports Gandi V5 API and built in Go.
+- [DDClient](https://github.com/ddclient/ddclient) - The most popular open-source DDNS client that supports Gandi LiveDNS.
 
 ## APIs
 


### PR DESCRIPTION
I added few links of libs, deployment tools and clients that uses Gandi APIs (the Gandi v5 API or the outdated LiveDNS API).

A new category called `Clients` have been created to add Lego and DDClient.