### PR TITLE
Add a section for articles and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Libraries](#libraries)
 - [Deployment](#deployment)
 - [APIs](#apis)
+- [Docs & tutorials](#docs--tutorials)
 
 ## Libraries
 
@@ -20,3 +21,9 @@
 
 - [Gandi API](https://api.gandi.net) - The Gandi v5 API.
 - [Gandi Sandbox API](https://api.sandbox.gandi.net) - The Gandi v5 Sandbox API allowing you to use the API without creating any resources.
+
+## Docs & tutorials
+
+- [Gandi documentation](https://docs.gandi.net) - Official documentation.
+- [GandiCloud VPS tutorials](https://docs.gandi.net/en/cloud/vps/tutorials/index.html) - Tutorials made by Gandi with examples of what can be done with a GandiCloud VPS.
+- [Custom Linux distribution on GandiCloud VPS](https://mdk.fr/blog/how-to-install-any-distrib-on-a-gandi-vps.html) - Article about how to install any distribution on a GandiCloud VPS.


### PR DESCRIPTION
Not sure if it could be useful to add links to other "tutorials" sections of the official documentation, e.g. https://docs.gandi.net/en/simple_hosting/tutorials/index.html
On one hand I could find it useful because I would not dig into the "documentation" link to find "how-to" tutorials naturally, but on the other having multiple links to the same resource is not ideal.

Also @julienpalard would you be ok to have your article listed in this (new) repository?